### PR TITLE
Maybe is 3% fee tax instead of 97% ?

### DIFF
--- a/src/FlashToken.sol
+++ b/src/FlashToken.sol
@@ -9,6 +9,6 @@ contract FlashToken is ERC20FlashMint {
     }
 
     function _flashFee(address, uint256 amount) internal pure override returns (uint256) {
-        return amount * 97 / 100;
+        return amount * 3 / 100;
     }
 }


### PR DESCRIPTION
Parameter fee tax (%) is used in the function _flashFee / contract FlashToken:

    function _flashFee(address, uint256 amount) internal pure override returns (uint256) {
        return amount * 97 / 100;
    }